### PR TITLE
ci: fix duplicate workflow runs and gate Docker by tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,14 @@
 name: CI
 
 on:
-  - push
-  - pull_request
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   cache-and-install:


### PR DESCRIPTION
## Summary
- Restrict push trigger to default branch + tags
- Add concurrency group to cancel superseded runs

## Test plan
- [ ] Verify PRs trigger CI once (not twice)
- [ ] Verify Docker push only happens on tag push